### PR TITLE
Update twilio-sms.sh with new /Messages endpoint

### DIFF
--- a/twilio-sms.sh
+++ b/twilio-sms.sh
@@ -76,7 +76,7 @@ if [ -z "$MSG" ]; then usage "No content for the SMS was read from STDIN."; fi;
 for PHONE in "${@:$OPTIND}"; do
 	echo -n "Sending SMS to $PHONE from $CALLERID..."
 	# initiate a curl request to the Twilio REST API, to begin a phone call to that number
-	RESPONSE=`curl -fSs -u "$ACCOUNTSID:$AUTHTOKEN" -d "From=$CALLERID" -d "To=$PHONE" -d "Body=$MSG" "https://api.twilio.com/2010-04-01/Accounts/$ACCOUNTSID/SMS/Messages" 2>&1`
+	RESPONSE=`curl -fSs -u "$ACCOUNTSID:$AUTHTOKEN" -d "From=$CALLERID" -d "To=$PHONE" -d "Body=$MSG" "https://api.twilio.com/2010-04-01/Accounts/$ACCOUNTSID/Messages" 2>&1`
 	echo $RESPONSE >> twilio_response.log
 	if [ $? -gt 0 ]; then echo "Failed to send SMS to $PHONE: $RESPONSE"
 	else echo "ok"


### PR DESCRIPTION
The /SMS/Messages endpoint is deprecated and has been fully shutdown, now just returns HTTP 410. This update removes the /SMS to get the script working again. Twilio deprecation notice: https://support.twilio.com/hc/en-us/articles/223181028-Switching-from-SMS-Messages-resource-URI-to-Messages-resource-URI-